### PR TITLE
Use Keyword Arguments for `register`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    drippings (0.1.0)
+    drippings (0.2.0)
       rails
 
 GEM

--- a/lib/drippings/client.rb
+++ b/lib/drippings/client.rb
@@ -28,7 +28,7 @@ module Drippings
       end
     end
 
-    def register(name, job, scope, wait_until = nil, time_zone = nil, options: {})
+    def register(name, job, scope, wait_until: nil, time_zone: nil, options: {})
       raise ArgumentError, "A drip has already been registered for #{name}" if @drips[name].present?
       raise ArgumentError, 'Job must be a subclass of Drippings::ProcessJob' unless job < Drippings::ProcessJob
       if wait_until.present? && time_zone.nil?

--- a/lib/drippings/version.rb
+++ b/lib/drippings/version.rb
@@ -1,3 +1,3 @@
 module Drippings
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.2.0'.freeze
 end

--- a/spec/drippings/client_spec.rb
+++ b/spec/drippings/client_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Drippings::Client do
     client.register(
       name,
       LeadFollowupJob, -> { Lead.all },
-      wait_until,
-      ->(lead) { lead.time_zone },
+      wait_until: wait_until,
+      time_zone: ->(lead) { lead.time_zone },
       options: {
         phone: phone,
         transactional: transactional


### PR DESCRIPTION
## Context
Switch both `wait_until:` and `time_zone:` to match README and use keyword arguments. This is a bit easier to read when registering lots of drips.